### PR TITLE
docs: fixed typo

### DIFF
--- a/components/PlaygroundSettings.vue
+++ b/components/PlaygroundSettings.vue
@@ -27,7 +27,7 @@
           :class="{ 'bg-gray-800 border-gray-800 ': syntax === 'select', 'bg-gray-500 border-gray-500': syntax !== 'select' }"
           @click="syntax = 'select'"
         >
-          Only intall this component
+          Only install this component
         </button>
         <button
           type="button"


### PR DESCRIPTION
I was using the playground and I found this little typo

![image](https://user-images.githubusercontent.com/4997549/145886420-4703db1a-08a8-43e9-ae06-980a3eb08dfd.png)
